### PR TITLE
Increase max metadata value size to 2KB

### DIFF
--- a/swift/swift.conf
+++ b/swift/swift.conf
@@ -2,3 +2,6 @@
 # random unique strings that can never change (DO NOT LOSE)
 swift_hash_path_prefix = veDDnRGXVW7rXqc3
 swift_hash_path_suffix = 0rBOk3EM17yId7Ke
+
+[swift-constraints]
+max_meta_value_length = 2048


### PR DESCRIPTION
AWS S3 allows max metadata size of 2KB. It's computed as the sum of the key and value.

Swift by default constrains the metadata value size to 256bytes, which is too low and not really compatible with what S3 provides.